### PR TITLE
:sparkles: Change workstatus naming

### DIFF
--- a/pkg/agent/reconcilers.go
+++ b/pkg/agent/reconcilers.go
@@ -122,7 +122,7 @@ func (a *Agent) updateWorkStatus(obj runtime.Object) error {
 	// check if WorkStatus exists and if not create it
 	workStatus := &v1alpha1.WorkStatus{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      util.BuildWorkstatusName(obj),
 			Namespace: namespace,
 		},
 	}

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,4 +171,17 @@ func GetGVR(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVe
 	}
 
 	return mapping.Resource, nil
+}
+
+// BuildWorkstatusName returns string in format: <groupversion>-<kind>-<namespace>-<name>
+func BuildWorkstatusName(obj any) string {
+	mObj := obj.(metav1.Object)
+	rObj := obj.(runtime.Object)
+	gvk := rObj.GetObjectKind().GroupVersionKind()
+	return fmt.Sprintf("%s-%s-%s-%s",
+		strings.ToLower(strings.ReplaceAll(gvk.GroupVersion().String(), "/", "")),
+		strings.ToLower(gvk.Kind),
+		mObj.GetNamespace(),
+		mObj.GetName(),
+	)
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The status addon is already iterate over the list of workload objects in the manifestwork, but a workstatus object is created with the same name as the manifestwork, so only 1 workstatus is created.
This PR will change the naming to support multi-wrapped objects.
Names will be in a similar format as the manifestwork names i.e. groupversion-kind-namespace-name

## Related issue(s)
https://github.com/kubestellar/kubestellar/issues/1680

Fixes #
