### PR TITLE
:sparkles: Add the AppliedManifestWork update reconciliation

### DIFF
--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -195,6 +195,7 @@ rules:
   - workstatuses
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -34,24 +34,12 @@ func ListGVRs(aWork *workv1.AppliedManifestWork) []*schema.GroupVersionResource 
 	return gvrs
 }
 
-func AddTrackedObjectsUID(aWork *workv1.AppliedManifestWork, trackedObjs map[string]string) {
-	for _, appliedResource := range aWork.Status.AppliedResources {
-		trackedObjs[appliedResource.UID] = aWork.Spec.ManifestWorkName
-	}
-}
-
 func GetTrackedObjectsUID(aWork *workv1.AppliedManifestWork) []string {
 	uids := []string{}
 	for _, appliedResource := range aWork.Status.AppliedResources {
 		uids = append(uids, appliedResource.UID)
 	}
 	return uids
-}
-
-func RemoveTrackedObjectsUID(uids []string, trackedObjs map[string]string) {
-	for _, uid := range uids {
-		delete(trackedObjs, uid)
-	}
 }
 
 func GetManifestWork(c client.Client, name, namespace string) (*workv1.ManifestWork, error) {

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -29,7 +29,7 @@ func AddonRBAC(kubeConfig *rest.Config) agent.PermissionConfigFunc {
 				Namespace: cluster.Name,
 			},
 			Rules: []rbacv1.PolicyRule{
-				{Verbs: []string{"get", "list", "watch", "create", "update"}, Resources: []string{"workstatuses"}, APIGroups: []string{"edge.kubestellar.io"}},
+				{Verbs: []string{"get", "list", "watch", "create", "delete", "update"}, Resources: []string{"workstatuses"}, APIGroups: []string{"edge.kubestellar.io"}},
 				{Verbs: []string{"patch", "update"}, Resources: []string{"workstatuses/status"}, APIGroups: []string{"edge.kubestellar.io"}},
 				{Verbs: []string{"get", "list", "watch"}, Resources: []string{"managedclusteraddons"}, APIGroups: []string{"addon.open-cluster-management.io"}},
 				{Verbs: []string{"get", "list", "watch"}, Resources: []string{"manifestworks"}, APIGroups: []string{"work.open-cluster-management.io"}},

--- a/pkg/util/safemaps.go
+++ b/pkg/util/safemaps.go
@@ -86,3 +86,38 @@ func HasPrefixInMap(m map[string]string, prefix string) bool {
 	}
 	return false
 }
+
+// SafeTrackedObjectstMap maps tracked object UID to the manifestWork name
+type SafeTrackedObjectstMap struct {
+	mu sync.Mutex
+	v  map[string]string
+}
+
+func NewSafeTrackedObjectstMap() *SafeTrackedObjectstMap {
+	return &SafeTrackedObjectstMap{
+		v: make(map[string]string),
+	}
+}
+
+func (s *SafeTrackedObjectstMap) Get(key string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.v[key]
+	return v, ok
+}
+
+func (s *SafeTrackedObjectstMap) AddTrackedObjectsUID(uids []string, manifestWorkName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, uid := range uids {
+		s.v[uid] = manifestWorkName
+	}
+}
+
+func (s *SafeTrackedObjectstMap) RemoveTrackedObjectsUID(uids []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, uid := range uids {
+		delete(s.v, uid)
+	}
+}

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,17 +170,4 @@ func GetGVR(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVe
 	}
 
 	return mapping.Resource, nil
-}
-
-// BuildWorkstatusName returns string in format: <groupversion>-<kind>-<namespace>-<name>
-func BuildWorkstatusName(obj any) string {
-	mObj := obj.(metav1.Object)
-	rObj := obj.(runtime.Object)
-	gvk := rObj.GetObjectKind().GroupVersionKind()
-	return fmt.Sprintf("%s-%s-%s-%s",
-		strings.ToLower(strings.ReplaceAll(gvk.GroupVersion().String(), "/", "")),
-		strings.ToLower(gvk.Kind),
-		mObj.GetNamespace(),
-		mObj.GetName(),
-	)
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GetAddedRemovedInfo compares the updated AppliedManifestInfo to the base AppliedManifestInfo
+// and returns AppliedManifestInfos for added and removed elements.
+func GetAddedRemovedInfo(base AppliedManifestInfo, updated AppliedManifestInfo) (added, removed AppliedManifestInfo) {
+	baseUIDs := base.ObjectUIDs
+	updatedUIDs := updated.ObjectUIDs
+	if len(baseUIDs) == 0 {
+		return updated, removed
+	}
+	if len(updatedUIDs) == 0 {
+		return added, base
+	}
+	baseGVRs := base.GVRs
+	updatedGVRs := updated.GVRs
+	// convert slices to maps for better performance
+	mapBase := make(map[string]*schema.GroupVersionResource)
+	mapUpdated := make(map[string]*schema.GroupVersionResource)
+	for i, val := range baseUIDs {
+		mapBase[val] = baseGVRs[i]
+	}
+	for i, val := range updatedUIDs {
+		mapUpdated[val] = updatedGVRs[i]
+	}
+
+	for key := range mapBase {
+		if _, ok := mapUpdated[key]; !ok {
+			removed.ObjectUIDs = append(removed.ObjectUIDs, key)
+			removed.GVRs = append(removed.GVRs, mapBase[key])
+		} else {
+			delete(mapUpdated, key)
+		}
+	}
+	for key := range mapUpdated {
+		added.ObjectUIDs = append(added.ObjectUIDs, key)
+		added.GVRs = append(added.GVRs, mapUpdated[key])
+	}
+	return added, removed
+}
+
+// BuildWorkstatusName returns string in format: <groupversion>-<kind>-<namespace>-<name>
+func BuildWorkstatusName(obj any) string {
+	mObj := obj.(metav1.Object)
+	rObj := obj.(runtime.Object)
+	gvk := rObj.GetObjectKind().GroupVersionKind()
+	return fmt.Sprintf("%s-%s-%s-%s",
+		strings.ToLower(strings.ReplaceAll(gvk.GroupVersion().String(), "/", "")),
+		strings.ToLower(gvk.Kind),
+		mObj.GetNamespace(),
+		mObj.GetName(),
+	)
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR will add reconciliation on the update events for the AppliedManifestWork objects.
The reconcile loop will find and process changes to the list of resources in the AppliedManifestWork object.
The WorkStatus object on the hub will be deleted when the workload object on the WEC is deleted. 

## Related issue(s)

Fixes # https://github.com/kubestellar/kubestellar/issues/1724
