### PR TITLE
✨ Consistent API group for WorkStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and RBAC permissions to enable this functionality.
     kubectl --context imbs1 -n cluster1 get managedclusteraddons addon-status
     kubectl --context imbs1 -n cluster2 get managedclusteraddons addon-status
     ```
-    After agents start and are running, `AVAILABLE`` should be `True` on both namespaces
+    After agents start and are running, `AVAILABLE` should be `True` on both namespaces
 
 ## Using the Add-On
 

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the placement v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=edge.kubestellar.io
+// +groupName=control.kubestellar.io
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "edge.kubestellar.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "control.kubestellar.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
-  name: workstatuses.edge.kubestellar.io
+  name: workstatuses.control.kubestellar.io
 spec:
-  group: edge.kubestellar.io
+  group: control.kubestellar.io
   names:
     kind: WorkStatus
     listKind: WorkStatusList
@@ -190,7 +190,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - edge.kubestellar.io
+  - control.kubestellar.io
   resources:
   - workstatuses
   verbs:
@@ -201,7 +201,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - edge.kubestellar.io
+  - control.kubestellar.io
   resources:
   - workstatuses/status
   verbs:

--- a/config/crd/bases/control.kubestellar.io_workstatuses.yaml
+++ b/config/crd/bases/control.kubestellar.io_workstatuses.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
-  name: workstatuses.edge.kubestellar.io
+  name: workstatuses.control.kubestellar.io
 spec:
-  group: edge.kubestellar.io
+  group: control.kubestellar.io
   names:
     kind: WorkStatus
     listKind: WorkStatusList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,5 +2,5 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/edge.kubestellar.io_workstatuses.yaml
+- bases/control.kubestellar.io_workstatuses.yaml
 #+kubebuilder:scaffold:crdkustomizeresource

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,7 +7,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: ko.local/ocm-status-addon
-  newTag: d66eeb5
+  newTag: 3f873d1
 
 replacements:
 - source:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,18 +98,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - edge.kubestellar.io
+  - control.kubestellar.io
   resources:
   - workstatuses
   verbs:
@@ -120,12 +109,23 @@ rules:
   - update
   - watch
 - apiGroups:
-  - edge.kubestellar.io
+  - control.kubestellar.io
   resources:
   - workstatuses/status
   verbs:
   - patch
   - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/pkg/internal/kubebuilder-gen.go
+++ b/pkg/internal/kubebuilder-gen.go
@@ -26,8 +26,8 @@ import (
 type NoOpReconciler struct {
 }
 
-//+kubebuilder:rbac:groups=edge.kubestellar.io,resources=workstatuses,verbs=get;list;watch;create;update;delete
-//+kubebuilder:rbac:groups=edge.kubestellar.io,resources=workstatuses/status,verbs=update;patch
+//+kubebuilder:rbac:groups=control.kubestellar.io,resources=workstatuses,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=control.kubestellar.io,resources=workstatuses/status,verbs=update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps;events,verbs=get;list;watch;create;update;delete;deletecollection;patch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;delete

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -29,8 +29,8 @@ func AddonRBAC(kubeConfig *rest.Config) agent.PermissionConfigFunc {
 				Namespace: cluster.Name,
 			},
 			Rules: []rbacv1.PolicyRule{
-				{Verbs: []string{"get", "list", "watch", "create", "delete", "update"}, Resources: []string{"workstatuses"}, APIGroups: []string{"edge.kubestellar.io"}},
-				{Verbs: []string{"patch", "update"}, Resources: []string{"workstatuses/status"}, APIGroups: []string{"edge.kubestellar.io"}},
+				{Verbs: []string{"get", "list", "watch", "create", "delete", "update"}, Resources: []string{"workstatuses"}, APIGroups: []string{"control.kubestellar.io"}},
+				{Verbs: []string{"patch", "update"}, Resources: []string{"workstatuses/status"}, APIGroups: []string{"control.kubestellar.io"}},
 				{Verbs: []string{"get", "list", "watch"}, Resources: []string{"managedclusteraddons"}, APIGroups: []string{"addon.open-cluster-management.io"}},
 				{Verbs: []string{"get", "list", "watch"}, Resources: []string{"manifestworks"}, APIGroups: []string{"work.open-cluster-management.io"}},
 			},


### PR DESCRIPTION
## Summary
This PR changes the API group for WorkStatus so as to be consistent with other KubeStellar APIs.

In terms of test, this PR is still using the 1 hub + 2 managed cluster scenario, and the singleton status return example. What's special are:
1. The status addon is built with `make ko-local-build`, then loaded the image into the kind clusters;
2. `make deploy` the status addon;
3. Make changes to the KS/KS repo, then in KS/KS, `make ko-build-local` the KS controller manager;
4. `make install-local-chart KUBE_CONTEXT=kind-kubeflex` the KS controller manager.

Here is the log of the agent, as well as the observed WorkStatus:
```
ubuntu@ip-172-31-38-158:kubestellar$ kubectl --context cluster1 -n open-cluster-management-agent-addon logs deploy/status-agent --tail 5
2024-02-16T01:49:39Z	INFO	going to update status:	{"object": "[open-cluster-management-agent-addon] deployment.apps/status-agent"}
2024-02-16T01:49:39Z	INFO	Got applied manifest work	{"name": "60a1cce86bd34bbda5f132f6f67b6cb97292a110b8c1757ab8a38eaf080efe81-appsv1-deployment-nginx-nginx-deployment", "isBeingDeleted": false}
2024-02-16T01:49:39Z	INFO	object not managed by a KS placement, status not updated	{"object": "addon-addon-status-deploy-0", "namespace": "cluster1"}
2024-02-16T01:49:39Z	INFO	going to update status:	{"object": "[nginx] deployment.apps/nginx-deployment"}
2024-02-16T01:49:43Z	INFO	going to update status:	{"object": "[nginx] deployment.apps/nginx-deployment"}
ubuntu@ip-172-31-38-158:kubestellar$ kubectl --context imbs1 -n cluster1 get workstatus.control appsv1-deployment-nginx-nginx-deployment -oyaml
apiVersion: control.kubestellar.io/v1alpha1
kind: WorkStatus
metadata:
  creationTimestamp: "2024-02-16T01:49:39Z"
  generation: 1
  labels:
    managed-by.kubestellar.io/singletonstatus: "true"
    managed-by.kubestellar.io/wds1.nginx-singleton-bindingpolicy: "true"
  name: appsv1-deployment-nginx-nginx-deployment
  namespace: cluster1
  ownerReferences:
  - apiVersion: work.open-cluster-management.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: ManifestWork
    name: appsv1-deployment-nginx-nginx-deployment
    uid: 68b18f55-0ca9-4002-a8c7-9b1413698867
  resourceVersion: "1012"
  uid: ee1d2d69-9d22-4a8e-89b0-e2578bd38384
spec:
  sourceRef:
    group: apps
    kind: Deployment
    name: nginx-deployment
    namespace: nginx
    resource: deployments
    version: v1
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2024-02-16T01:49:43Z"
    lastUpdateTime: "2024-02-16T01:49:43Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2024-02-16T01:49:39Z"
    lastUpdateTime: "2024-02-16T01:49:43Z"
    message: ReplicaSet "nginx-deployment-7dd74d45b5" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 1
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
ubuntu@ip-172-31-38-158:kubestellar$
```
We may need a new tag of the status addon chart, then do https://github.com/kubestellar/kubestellar/issues/1701, which will include the changes in step 3 above.
