### PR TITLE
:sparkles: Copy singleton label from the workload object

### DIFF
--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -200,6 +200,7 @@ rules:
   - list
   - update
   - watch
+  - patch
 - apiGroups:
   - control.kubestellar.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -105,6 +105,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/pkg/agent/informers.go
+++ b/pkg/agent/informers.go
@@ -35,7 +35,7 @@ func (a *Agent) startInformers(gvrs []*schema.GroupVersionResource, uids []strin
 
 		// we do not need to start informers for objects that do not have status
 		if _, ok := excludedGVKs[gvk.String()]; ok {
-			return
+			continue
 		}
 
 		key := util.KeyForGroupVersionKind(gvk.Group, gvk.Version, gvk.Kind)

--- a/pkg/agent/reconcilers.go
+++ b/pkg/agent/reconcilers.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	ManagedByKSLabelKeyPrefix = "managed-by.kubestellar.io"
+	SingletonstatusLabelKey  = "managed-by.kubestellar.io/singletonstatus"
 )
 
 // main reconciliation loop. The returned bool value allows to re-enque even if no errors
@@ -184,6 +185,12 @@ func (a *Agent) updateWorkStatus(obj runtime.Object, isBeingDeleted bool) error 
 			// TODO - need to do this also when labels are updated on manifest work
 			// TODO - there are currently no labels on workstatus but should consider merging in case labels are set
 			workStatus.Labels = manifestWork.Labels
+
+			// copy singleton label from the object, if exist
+			objLabels := mObj.GetLabels()
+			if val, ok := objLabels[SingletonstatusLabelKey]; ok {
+				workStatus.Labels[SingletonstatusLabelKey] = val
+			}
 
 			// set object ref
 			gvk := schema.GroupVersionKind{

--- a/pkg/agent/reconcilers.go
+++ b/pkg/agent/reconcilers.go
@@ -23,7 +23,8 @@ import (
 
 const (
 	ManagedByKSLabelKeyPrefix = "managed-by.kubestellar.io"
-	SingletonstatusLabelKey  = "managed-by.kubestellar.io/singletonstatus"
+	TransportLabelPrefix      = "transport.kubestellar.io"
+	SingletonstatusLabelKey   = "managed-by.kubestellar.io/singletonstatus"
 )
 
 // main reconciliation loop. The returned bool value allows to re-enque even if no errors
@@ -173,7 +174,8 @@ func (a *Agent) updateWorkStatus(obj runtime.Object, isBeingDeleted bool) error 
 			}
 
 			// only update status for KS-managed (by bindingpolicies here) objects
-			if !util.HasPrefixInMap(manifestWork.Labels, ManagedByKSLabelKeyPrefix) {
+			// TODO remove the check for ManagedByKSLabelKeyPrefix after we switch to new transport
+			if !util.HasPrefixInMap(manifestWork.Labels, ManagedByKSLabelKeyPrefix) && !util.HasPrefixInMap(manifestWork.Labels, TransportLabelPrefix) {
 				a.logger.Info("object not managed by a KS bindingpolicy, status not updated", "object", name, "namespace", namespace)
 				return nil
 			}

--- a/pkg/internal/kubebuilder-gen.go
+++ b/pkg/internal/kubebuilder-gen.go
@@ -26,7 +26,7 @@ import (
 type NoOpReconciler struct {
 }
 
-//+kubebuilder:rbac:groups=control.kubestellar.io,resources=workstatuses,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=control.kubestellar.io,resources=workstatuses,verbs=get;list;watch;create;update;delete;patch
 //+kubebuilder:rbac:groups=control.kubestellar.io,resources=workstatuses/status,verbs=update;patch
 //+kubebuilder:rbac:groups="",resources=configmaps;events,verbs=get;list;watch;create;update;delete;deletecollection;patch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -29,7 +29,7 @@ func AddonRBAC(kubeConfig *rest.Config) agent.PermissionConfigFunc {
 				Namespace: cluster.Name,
 			},
 			Rules: []rbacv1.PolicyRule{
-				{Verbs: []string{"get", "list", "watch", "create", "delete", "update"}, Resources: []string{"workstatuses"}, APIGroups: []string{"control.kubestellar.io"}},
+				{Verbs: []string{"get", "list", "watch", "create", "delete", "update", "patch"}, Resources: []string{"workstatuses"}, APIGroups: []string{"control.kubestellar.io"}},
 				{Verbs: []string{"patch", "update"}, Resources: []string{"workstatuses/status"}, APIGroups: []string{"control.kubestellar.io"}},
 				{Verbs: []string{"get", "list", "watch"}, Resources: []string{"managedclusteraddons"}, APIGroups: []string{"addon.open-cluster-management.io"}},
 				{Verbs: []string{"get", "list", "watch"}, Resources: []string{"manifestworks"}, APIGroups: []string{"work.open-cluster-management.io"}},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
New pluggable transport introduced by PR https://github.com/kubestellar/kubestellar/pull/1765 will add the singleton label to the workload object instead of the ManifestWork object.
This PR is a preparation for the new pluggable transport and it will propagate the singleton label from the workload object to the WorkStatus.
This is not a breaking change, the singleton label from the ManifestWork is still propagated.

## Related issue(s)

Fixes #
