### PR TITLE
:sparkles: Verify only the transport label prefix

### DIFF
--- a/pkg/agent/reconcilers.go
+++ b/pkg/agent/reconcilers.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	ManagedByKSLabelKeyPrefix = "managed-by.kubestellar.io"
-	TransportLabelPrefix      = "transport.kubestellar.io"
-	SingletonstatusLabelKey   = "managed-by.kubestellar.io/singletonstatus"
+	TransportKSLabelKeyPrefix = "transport.kubestellar.io"
+	SingletonstatusKSLabelKey = "managed-by.kubestellar.io/singletonstatus"
 )
 
 // main reconciliation loop. The returned bool value allows to re-enque even if no errors
@@ -174,8 +173,7 @@ func (a *Agent) updateWorkStatus(obj runtime.Object, isBeingDeleted bool) error 
 			}
 
 			// only update status for KS-managed (by bindingpolicies here) objects
-			// TODO remove the check for ManagedByKSLabelKeyPrefix after we switch to new transport
-			if !util.HasPrefixInMap(manifestWork.Labels, ManagedByKSLabelKeyPrefix) && !util.HasPrefixInMap(manifestWork.Labels, TransportLabelPrefix) {
+			if !util.HasPrefixInMap(manifestWork.Labels, TransportKSLabelKeyPrefix) {
 				a.logger.Info("object not managed by a KS bindingpolicy, status not updated", "object", name, "namespace", namespace)
 				return nil
 			}
@@ -191,8 +189,8 @@ func (a *Agent) updateWorkStatus(obj runtime.Object, isBeingDeleted bool) error 
 
 			// copy singleton label from the object, if exist
 			objLabels := mObj.GetLabels()
-			if val, ok := objLabels[SingletonstatusLabelKey]; ok {
-				workStatus.Labels[SingletonstatusLabelKey] = val
+			if val, ok := objLabels[SingletonstatusKSLabelKey]; ok {
+				workStatus.Labels[SingletonstatusKSLabelKey] = val
 			}
 
 			// set object ref
@@ -225,9 +223,9 @@ func (a *Agent) updateWorkStatus(obj runtime.Object, isBeingDeleted bool) error 
 
 	// patch the workStatus with singleton label if the object was labeled
 	objLabels := mObj.GetLabels()
-	if val, ok := objLabels[SingletonstatusLabelKey]; ok {
-		if _, ok := workStatus.Labels[SingletonstatusLabelKey]; !ok {
-			patchString := fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, SingletonstatusLabelKey, val)
+	if val, ok := objLabels[SingletonstatusKSLabelKey]; ok {
+		if _, ok := workStatus.Labels[SingletonstatusKSLabelKey]; !ok {
+			patchString := fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, SingletonstatusKSLabelKey, val)
 			err = a.hubClient.Patch(ctx, workStatus, client.RawPatch(types.MergePatchType, []byte(patchString)))
 			if err != nil {
 				return err

--- a/test/e2e/workstatus-creation.sh
+++ b/test/e2e/workstatus-creation.sh
@@ -34,15 +34,23 @@ apiVersion: work.open-cluster-management.io/v1
 kind: ManifestWork
 metadata:
   labels:
-    managed-by.kubestellar.io/something: "true"
+    transport.kubestellar.io/something: wds1
   name: nginx-deployment
   namespace: cluster1
 spec:
   workload:
     manifests:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          managed-by.kubestellar.io/singletonstatus: bindingpolicy
+        name: nginx
     - apiVersion: apps/v1
       kind: Deployment
       metadata:
+        labels:
+          managed-by.kubestellar.io/singletonstatus: bindingpolicy
         name: nginx
         namespace: nginx
       spec:
@@ -60,19 +68,6 @@ spec:
               image: public.ecr.aws/nginx/nginx:latest 
               ports:
               - containerPort: 80
----
-apiVersion: work.open-cluster-management.io/v1
-kind: ManifestWork
-metadata:
-  name: nginx-namespace
-  namespace: cluster1
-spec:
-  workload:
-    manifests:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: nginx
 EOF
 
 :


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. Now that PR https://github.com/kubestellar/kubestellar/pull/1765 was merged we can remove the workaround for verifying both `managed-by` and `transport` labels prefix when we want to determine whether an object is managed by BindingPolicy.
2. Update the e2e test to use new labels and multi-wrapped objects.

## Related issue(s)

Fixes #
