### PR TITLE
🐛 add x-kubernetes-map-type: atomic to crd and improve logging

### DIFF
--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -63,6 +63,7 @@ spec:
           status:
             description: Manifest represents a resource to be deployed
             type: object
+            x-kubernetes-map-type: atomic
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
@@ -292,8 +293,8 @@ spec:
         - controller
         env:
         - name: STATUS_ADDDON_IMAGE_NAME
-          value: ko.local/ocm-status-addon:cf3479e
-        image: ko.local/ocm-status-addon:cf3479e
+          value: ko.local/ocm-status-addon:to_be_replaced
+        image: ko.local/ocm-status-addon:to_be_replaced
         imagePullPolicy: IfNotPresent
         name: status-controller
         resources:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,4 +3,13 @@
 # It should be run by config/default
 resources:
 - bases/control.kubestellar.io_workstatuses.yaml
+
+patchesJson6902:
+  - path: patch.yaml
+    target:
+       group: apiextensions.k8s.io
+       version: v1
+       kind: CustomResourceDefinition
+       name: workstatuses.control.kubestellar.io
+
 #+kubebuilder:scaffold:crdkustomizeresource

--- a/config/crd/patch.yaml
+++ b/config/crd/patch.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/status/x-kubernetes-map-type
+  value: atomic
+


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

minor improvements to CRD with x-kubernetes-map-type: atomic and clearer logging for handle WorkStatus


