### PR TITLE
🌱 Make unit tests not require envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+test: manifests generate fmt vet ## Run tests.
+	go test ./... -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
When we look at [a failed CI check](https://github.com/kubestellar/ocm-status-addon/actions/runs/8395574539/job/22995127146?pr=49), we see the `invalid go version '1.22.0': must match format 1.23` message. Looks like it is due to some recent [change](https://github.com/kubernetes-sigs/controller-runtime/commit/4c2442e4d743d172a2e0126a841ecd274fffc228) that includes patch version of go in go.mod. It is suggested developers should not include patch version, as discussed [here](https://github.com/golang/go/issues/61888).

We can just disable envtest for now because we are not yet using it, similar to what we did in https://github.com/kubestellar/kubestellar/pull/1921.
