### PR TITLE
🌱 Remove use of zap logging

### DIFF
--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -36,7 +36,6 @@ import (
 	cmdfactory "open-cluster-management.io/addon-framework/pkg/cmd/factory"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	v1alpha1 "github.com/kubestellar/ocm-status-addon/api/v1alpha1"
 	clientopts "github.com/kubestellar/ocm-status-addon/pkg/client-options"
@@ -73,7 +72,6 @@ func NewAgentCommand(addonName string) *cobra.Command {
 
 // AgentOptions defines the flags for workload agent
 type AgentOptions struct {
-	ZapOpts              zap.Options
 	MetricsAddr          string
 	EnableLeaderElection bool
 	ProbeAddr            string
@@ -88,7 +86,6 @@ type AgentOptions struct {
 // NewAgentOptions returns the flags with default value set
 func NewAgentOptions(addonName string) *AgentOptions {
 	return &AgentOptions{
-		ZapOpts:     zap.Options{Development: true},
 		AddonName:   addonName,
 		LocalLimits: clientopts.NewClientLimits[*pflag.FlagSet]("local", "accessing the local cluster"),
 		HubLimits:   clientopts.NewClientLimits[*pflag.FlagSet]("hub", "accessing the hub"),
@@ -98,7 +95,6 @@ func NewAgentOptions(addonName string) *AgentOptions {
 func (o *AgentOptions) AddFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
 	forZap := flag.NewFlagSet("agent", flag.ExitOnError)
-	o.ZapOpts.BindFlags(forZap)
 	flags.AddGoFlagSet(forZap)
 	// This command only supports reading from config
 	flags.StringVar(&o.HubKubeconfigFile, "hub-kubeconfig", o.HubKubeconfigFile,
@@ -117,8 +113,6 @@ func (o *AgentOptions) AddFlags(cmd *cobra.Command) {
 
 func (o *AgentOptions) RunAgent(ctx context.Context, kubeconfig *rest.Config) error {
 	flag.Parse()
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&o.ZapOpts)))
 
 	// setup manager
 	// manager here is mainly used for leader election and health checks

--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -28,6 +28,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/version"
+	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -113,6 +114,7 @@ func (o *AgentOptions) AddFlags(cmd *cobra.Command) {
 
 func (o *AgentOptions) RunAgent(ctx context.Context, kubeconfig *rest.Config) error {
 	flag.Parse()
+	ctrl.SetLogger(klog.FromContext(ctx))
 
 	// setup manager
 	// manager here is mainly used for leader election and health checks


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes the use of zap logging in the agent because it is no longer needed, Kubernetes logging is now both leveled and structured.

## Related issue(s)

Fixes #
