### PR TITLE
🐛 Finish switch from zap to kube logging

### DIFF
--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -95,8 +95,6 @@ func NewAgentOptions(addonName string) *AgentOptions {
 
 func (o *AgentOptions) AddFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
-	forZap := flag.NewFlagSet("agent", flag.ExitOnError)
-	flags.AddGoFlagSet(forZap)
 	// This command only supports reading from config
 	flags.StringVar(&o.HubKubeconfigFile, "hub-kubeconfig", o.HubKubeconfigFile,
 		"Location of kubeconfig file to connect to hub cluster.")
@@ -113,7 +111,6 @@ func (o *AgentOptions) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *AgentOptions) RunAgent(ctx context.Context, kubeconfig *rest.Config) error {
-	flag.Parse()
 	ctrl.SetLogger(klog.FromContext(ctx))
 
 	// setup manager


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a bug and removes some junk.

The bug is https://github.com/kubestellar/ocm-status-addon/blob/e714bc58339c35eb3469365ef3fc130bd8e022c4/cmd/ocm-status-addon/main.go#L33 , which constructs a `logs.LoggingConfiguration`, uses it to add flags to the command line, and then drops it on the floor --- guaranteeing that those flags will have no effect.

In terms of behavior, the bug is that the command line flags for logging had no effect on the logging.

## Related issue(s)

Fixes #
