### PR TITLE
✨ Expose agent command line flags from controller

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -59,9 +59,21 @@ jobs:
         if: always()
         run: kubectl --context kind-hub get managedclusteraddons -A
 
+      - name: Show Deployment objects in hub
+        if: always()
+        run: kubectl --context kind-hub get deploy -A
+
+      - name: Show controller
+        if: always()
+        run: kubectl --context kind-hub get deploy -n open-cluster-management addon-status-controller -o yaml
+
       - name: Show manifestworks in hub
         if: always()
         run: kubectl --context kind-hub get manifestwork -oyaml -A
+
+      - name: Show agent
+        if: always()
+        run: kubectl --context kind-cluster1 get pods -n open-cluster-management-agent-addon -o yaml
 
       - name: Show workloads in cluster1
         if: always()

--- a/cmd/ocm-status-addon/main.go
+++ b/cmd/ocm-status-addon/main.go
@@ -111,8 +111,10 @@ func newControllerCommand() *cobra.Command {
 func (ac *agentController) getPropagatedSettings(*clusterv1.ManagedCluster, *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
 	settings := []string{}
 	for flagName, wrapped := range ac.NameToWrapped {
-		setting := "--" + flagName + "=" + wrapped.Value.String()
-		settings = append(settings, setting)
+		if wrapped.Changed {
+			setting := "--" + flagName + "=" + wrapped.Value.String()
+			settings = append(settings, setting)
+		}
 	}
 	return map[string]any{"PropagatedSettings": settings}, nil
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,4 +72,5 @@ spec:
           value: STATUS_ADDDON_IMAGE_NAME_PLACEHOLDER
         args:
         - "controller"
+        - "--agent-v=2"
 

--- a/pkg/controller/manifests/templates/deployment.yaml
+++ b/pkg/controller/manifests/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
           - "--hub-kubeconfig=/var/run/hub/kubeconfig"
           - "--cluster-name={{ .ClusterName }}"
           - "--addon-namespace={{ .AddonInstallNamespace }}"
+{{- if .PropagatedSettings}} {{- range $setting := .PropagatedSettings }}
+          - "{{ $setting }}"
+{{- end }} {{- end }}
         volumeMounts:
           - name: hub-config
             mountPath: /var/run/hub


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds command line flags to the controller that expose the functionality of the agent's command line flags about logging.

## Related issue(s)

This embodies the simple answer to #57
