### PR TITLE
🐛 Constant ordering for agent args

### DIFF
--- a/cmd/ocm-status-addon/main.go
+++ b/cmd/ocm-status-addon/main.go
@@ -5,6 +5,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -129,6 +130,7 @@ func (ac *agentController) getPropagatedSettings(*clusterv1.ManagedCluster, *add
 			settings = append(settings, setting)
 		}
 	}
+	sort.Strings(settings)
 	return map[string]any{"PropagatedSettings": settings}, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes the manager use a constant ordering for the agent's command line flags. Before this, it was non-deterministic and the manager was thrashing the agent Deployment object badly.

## Related issue(s)

Fixes #
