### PR TITLE
🐛 Remove bogus exclusion of Namespace and Service

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -36,9 +36,7 @@ var excludedGVKs = map[string]bool{
 	"rbac.authorization.k8s.io/v1, Kind=RoleBinding":        true,
 	"/v1, Kind=Secret":         true,
 	"/v1, Kind=ConfigMap":      true,
-	"/v1, Kind=Namespace":      true,
 	"/v1, Kind=ServiceAccount": true,
-	"/v1, Kind=Service":        true,
 }
 
 // Agent tracks objects applied by the work agent by watching


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes Namespace and Service from the set of kinds of workload objects that do not get WorkStatus objects.

## Related issue(s)

Fixes #79 
