### PR TITLE
✨  Named Ports and Labels for Prometheus and Pyroscope scraping

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: ci
   name: kcp-dev-build-root
-  tag: "1.19.2"
+  tag: "1.21.2"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,13 @@ spec:
     metadata:
       labels:
         app: status-controller
+      annotations:
+        profiles.grafana.com/cpu.port: "9282"
+        profiles.grafana.com/cpu.scrape: "true"
+        profiles.grafana.com/goroutine.port: "9282"
+        profiles.grafana.com/goroutine.scrape: "true"
+        profiles.grafana.com/memory.port: "9282"
+        profiles.grafana.com/memory.scrape: "true"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -55,6 +62,13 @@ spec:
       - name: status-controller
         image: controller
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9280
+          protocol: TCP
+          name: metrics
+        - containerPort: 9282
+          protocol: TCP
+          name: debug-pprof
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/controller/manifests/templates/deployment.yaml
+++ b/pkg/controller/manifests/templates/deployment.yaml
@@ -14,6 +14,13 @@ spec:
     metadata:
       labels:
         app: status-agent
+      annotations:
+        profiles.grafana.com/cpu.port: "8082"
+        profiles.grafana.com/cpu.scrape: "true"
+        profiles.grafana.com/goroutine.port: "8082"
+        profiles.grafana.com/goroutine.scrape: "true"
+        profiles.grafana.com/memory.port: "8082"
+        profiles.grafana.com/memory.scrape: "true"
     spec:
       serviceAccountName: status-agent-sa
 {{- if .NodeSelector }}
@@ -42,6 +49,13 @@ spec:
       - name: status-agent
         image: {{ .Image }}
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+          name: metrics
+        - containerPort: 8082
+          protocol: TCP
+          name: debug-pprof
 {{- if or .HTTPProxy .HTTPSProxy}}
         env:
         {{- if .HTTPProxy }}


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds named ports and labels for Prometheus and Pyroscope scraping to the status-addon-controller and status-addon-agent.

## Related issue(s)

Fixes #

https://github.com/kubestellar/ocm-status-addon/issues/81