### PR TITLE
🌱 Let startInformers go

### DIFF
--- a/pkg/agent/informers.go
+++ b/pkg/agent/informers.go
@@ -52,13 +52,9 @@ func (a *Agent) startInformers(gvrs []*schema.GroupVersionResource, uids []strin
 		if count == 1 {
 			a.logger.Info("starting informer", "key", key)
 			stopper := make(chan struct{})
-			defer close(stopper)
 			a.startInformer(*gvr, gvk, stopper, true)
 		}
-
 	}
-	// block to avoid closing channel
-	select {}
 }
 
 func (a *Agent) startInformer(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, stopper chan struct{}, restartable bool) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR lets function `startInformers` return instead of block at the end.

This PR is a trial to fix #85 (and hopefully [#kubestellar/2040](https://github.com/kubestellar/kubestellar/issues/2040)).