### PR TITLE
✨  Extend setup script with wait for agent

### DIFF
--- a/test/e2e/setup-ocm-and-addon.sh
+++ b/test/e2e/setup-ocm-and-addon.sh
@@ -53,3 +53,10 @@ make ko-local-build
 make kind-load-image CLUSTERS="hub cluster1"
 make deploy DEFAULT_IMBS_CONTEXT=kind-hub CHART_INSTALL_EXTRA_ARGS="--set agent.v=2 --set agent.hub_burst=7"
 git restore config/manager/kustomization.yaml # restore newTag
+:
+: -------------------------------------------------------------------------
+: Wait for the agent to appear and come up
+:
+wait-for-cmd 'kubectl --context kind-cluster1 get deploy -n open-cluster-management-agent-addon status-agent'
+kubectl --context kind-cluster1 wait deploy -n open-cluster-management-agent-addon status-agent --for condition=Available --timeout 180s
+


### PR DESCRIPTION
This would expose the problem in PR 87 earlier.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR extends the `test/e2e/setup-ocm-and-addon.sh` script to wait for the agent to appear and go into business. This is failing to happen in #87, and this would have identified the problem earlier.

## Related issue(s)

Fixes #
