### PR TITLE
✨ Bump actions and switch to SHA instead of tag

### DIFF
--- a/.github/workflows/add-to-ks-project.yaml
+++ b/.github/workflows/add-to-ks-project.yaml
@@ -22,18 +22,18 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
      #     token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
       
-      - uses: actions/add-to-project@v1.0.2 # This adds the issue to the project
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # This adds the issue to the project
         with:
           project-url: https://github.com/orgs/kubestellar/projects/5
           github-token: ${{  secrets.GITHUB_TOKEN }}
         id: add-project
       
-      - uses: titoportas/update-project-fields@v0.1.0
+      - uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751
         with:
           project-url: https://github.com/orgs/kubestellar/projects/5
           github-token: ${{  secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     name: CI Checks
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: '1.24'
       - name: Lint

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -10,9 +10,9 @@ jobs:
     name: DCO Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v6.0.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: '3.x'
       - name: Check DCO

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@v6.0.0
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
       with:
         go-version: v1.24
 
@@ -35,7 +35,7 @@ jobs:
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
     - name: Run GoReleaser on tag
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
       with:
         distribution: goreleaser
         version: latest
@@ -46,12 +46,12 @@ jobs:
         EMAIL: ${{ github.actor}}@users.noreply.github.com
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Login to registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # The checkout step
-    - uses: actions/checkout@v4
-    - uses: rojopolis/spellcheck-github-actions@v0
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+    - uses: rojopolis/spellcheck-github-actions@6f2326b663e2dbab920da0fc4144b9f3202434ba
       name: Spellcheck
       with:
         config_path: .github/spellcheck/.spellcheck.yml # put path to configuration file here

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -19,19 +19,19 @@ jobs:
     name: Test workstatus operations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@v6.0.0
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: v1.24
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede
         id: install
 
       - name: Install and setup ko
-        uses: ko-build/setup-ko@v0.9
+        uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
         env:
           KO_DOCKER_REPO: ko.local
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the GitHub Actions workflows in `.github/workflows` to identify actions by SHA instead of tag, using the database (https://github.com/kubestellar/kubestellar/blob/main/.gha-reversemap.yml) and script (https://github.com/kubestellar/kubestellar/blob/main/hack/gha-reversemap.sh) from kubestellar/kubestellar . This required one manual reversion for the `kubernetes-sigs/kubebuilder-release-tools` Action because it is not in that database.

The bumps obviate #110, #110, and #112 .

## Related issue(s)

Fixes #
