### PR TITLE
🌱 fix: skip dependabot/renovate PRs in pr-verify-title workflow

### DIFF
--- a/.github/workflows/pr-verify-title.yml
+++ b/.github/workflows/pr-verify-title.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Skip PR title verification for dependabot and renovate bot PRs since they use their own naming conventions.