### PR TITLE
🌱 refactor: use centralized reusable workflows from infra

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -1,43 +1,10 @@
-name: Add Help Wanted, Good First Issue, or Hacktober Fest Labels
+name: Add Help Wanted Label
 
 on:
-  issue_comment:
-    types: [created]
-
-permissions:
-  issues: write
+  issues:
+    types: [opened]
 
 jobs:
-  label-on-comment:
-    if: github.event.comment.body == '/help-wanted' || github.event.comment.body == '/good-first-issue' || github.event.comment.body == '/hacktober-fest'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add label based on comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        with:
-          script: |
-            const comment = context.payload.comment.body.trim().toLowerCase();
-            const issue_number = context.payload.issue.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            let label = null;
-            if (comment === '/help-wanted') {
-              label = 'help wanted';
-            } else if (comment === '/good-first-issue') {
-              label = 'good first issue';
-            } else if (comment === '/hacktober-fest') {
-              label = 'hacktober-fest';
-            }
-
-            if (label) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number,
-                labels: [label],
-              });
-              console.log(`Added label: ${label}`);
-            } else {
-              console.log('No matching label to apply.');
-            }
+  add-label:
+    uses: kubestellar/infra/.github/workflows/reusable-add-help-wanted.yml@main
+    secrets: inherit

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -6,23 +6,5 @@ on:
 
 jobs:
   feedback:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-      contents: read
-
-    steps:
-      - name: Comment feedback request
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            🎉 Thank you for your contribution! Your PR has been successfully merged.
-
-            We’d love to hear your thoughts to help improve KubeStellar.
-            Please take a moment to fill out our short feedback survey:
-
-            https://kubestellar.io/survey
+    uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main
+    secrets: inherit

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -10,24 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  greeting:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
-            Thank you for contributing your first Issue to KubeStellar. We are delighted to have you in our Universe!
-
-            To assign yourself to this issue, please use the slash command:
-            ```
-            /assign
-            ```
-
-            This will automatically assign the issue to you via our Prow bot. You can also use `/unassign` to remove yourself from an issue.
-
-            Thank you for your interest in contributing to KubeStellar!
-          pr_message: "Thank you for submitting your first Pull Request to KubeStellar. We are delighted to have you in our Universe!"
+  greet:
+    uses: kubestellar/infra/.github/workflows/reusable-greetings.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -5,17 +5,6 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
-  verify-pr:
-    name: verify PR contents
-    # Skip verification for dependabot PRs - they use different title conventions
-    if: github.actor != 'dependabot[bot]'
-    permissions:
-      checks: write
-      pull-requests: read
-    runs-on: ubuntu-latest
-    steps:
-    - name: Verifier action
-      id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+  verify:
+    uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
+    secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,55 +1,14 @@
-# OpenSSF Scorecard - Security scoring and visibility
-# Based on https://github.com/ossf/scorecard-action
 name: OpenSSF Scorecard
 
 on:
-  # Run on changes to main branch
-  push:
-    branches:
-      - main
-  # Weekly scan
+  branch_protection_rule:
   schedule:
-    - cron: '0 6 * * 0'
-  # Allow manual trigger
+    - cron: '0 6 * * 1'
+  push:
+    branches: [ "main" ]
   workflow_dispatch:
-
-# Minimal default permissions - job-level permissions are set below
-permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecard analysis
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed for Code Scanning upload
-      security-events: write
-      # Needed for GitHub OIDC token if publish_results is true
-      id-token: write
-      # Required for repo access
-      contents: read
-      actions: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-
+    uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,29 +7,5 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d
-        with:
-          days-before-issue-stale: 90
-          days-before-issue-close: 90
-          stale-issue-label: lifecycle/stale
-          stale-pr-label: lifecycle/stale
-          stale-issue-message: >-
-            This issue has been automatically marked as stale because it has not had recent activity.
-            It will be closed in 90 days if no further activity occurs. If this is still relevant,
-            please add a comment to keep it open.
-          close-issue-message: >-
-            Closing this issue due to prolonged inactivity after being marked as stale. If this remains
-            an active concern, feel free to reopen or create a new issue with updated details.
-          close-issue-label: lifecycle/auto-closed
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          exempt-issue-labels: >-
-            security,bug,enhancement,good first issue,help wanted,hacktober-fest,
-            lifecycle/frozen
-          exempt-pr-labels: >-
-            security,lifecycle/frozen
-          exempt-all-assignees: true
+    uses: kubestellar/infra/.github/workflows/reusable-stale.yml@main
+    secrets: inherit


### PR DESCRIPTION
Migrate to org-wide reusable workflows for common CI tasks (greetings, feedback, stale, pr-verifier, add-help-wanted, scorecard). This reduces duplication and ensures consistent behavior across all KubeStellar repos.