### PR TITLE
🐛 Fix Feedback Wanted workflow permissions

### DIFF
--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   feedback:
     uses: kubestellar/infra/.github/workflows/reusable-feedback.yml@main


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission to feedback.yml

The reusable workflow needs this permission to post comments on merged PRs.

## Test plan
- [x] Verify reusable-feedback.yml requires pull-requests: write

🤖 Generated with [Claude Code](https://claude.com/claude-code)